### PR TITLE
feat: Provide an htmldependency directly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,8 @@ URL: https://rstudio.github.io/leaflet.providers/,
 BugReports: https://github.com/rstudio/leaflet.providers/issues
 Depends:
     R (>= 2.10)
+Imports: 
+    htmltools
 Suggests:
     jsonlite,
     testthat (>= 3.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,3 +37,4 @@ Collate:
     'providers_data.R'
     'get_current_providers.R'
     'leaflet.providers-package.R'
+    'zzz.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: leaflet.providers
 Title: Leaflet Providers
-Version: 1.13.0.9000
+Version: 1.13.0.9001
 Authors@R: c(
     person("Leslie", "Huang", , "lesliehuang@nyu.edu", role = "aut"),
     person("Barret", "Schloerke", , "barret@posit.co", role = c("ctb", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Updated leaflet.providers data on 2023-10-05 from https://unpkg.com/leaflet-providers using version 2.0.0 of leaflet.js
 
+* `get_providers()` and `default_providers()` both include a stable `htmltools::htmlDependency()` in the `dep` slot of the returned object. The default dependency uses the static `leaflet-providers.js` file included in the `leaflet.providers` package, while the `get_providers()` dependency uses the `leaflet-providers.js` file from the `unpkg.com` CDN. This makes it possible for `leaflet::addProviderTiles()` to use the stable HTML dependency that can be cached by knitr (#36).
+
 # leaflet.providers 1.13.0
 
 * Updated leaflet.providers data on 2023-08-07 from https://unpkg.com/leaflet-providers using version 1.13.0 of leaflet.js

--- a/R/get_current_providers.R
+++ b/R/get_current_providers.R
@@ -184,6 +184,3 @@ use_providers <- function(providers_info = NULL) {
 providers_loaded <- function() {
   as.list(loaded_providers_env$providers_info)
 }
-
-#' @include providers_data.R
-use_providers(providers_default())

--- a/R/get_current_providers.R
+++ b/R/get_current_providers.R
@@ -29,6 +29,11 @@ get_providers <- function(version_num = NULL) {
     return(get_providers(version_num))
   }
 
+  if (package_version(version_num) == package_version(providers_version_num)) {
+    # return the static, locally-stored leaflet.providers if possible
+    return(providers_default())
+  }
+
   unpkg_base <- paste0(unpkg_url, "@", version_num)
   js_path <- file.path(unpkg_base, "leaflet-providers.js")
 

--- a/R/get_current_providers.R
+++ b/R/get_current_providers.R
@@ -29,7 +29,8 @@ get_providers <- function(version_num = NULL) {
     return(get_providers(version_num))
   }
 
-  js_path <- paste0(unpkg_url, "@", version_num)
+  unpkg_base <- paste0(unpkg_url, "@", version_num)
+  js_path <- file.path(unpkg_base, "leaflet-providers.js")
 
   tmp_js_lines <- paste0(readLines(js_path), collapse = "\n")
 
@@ -64,11 +65,27 @@ get_providers <- function(version_num = NULL) {
     "version_num" = version_num,
     "providers" = providers,
     "providers_details" = providers_details,
-    "src" = tmp_js_lines
+    "src" = tmp_js_lines,
+    "dep" = leaflet_providers_dependency(version_num, js_path)
   )
 
   class(providers_info) <- "leaflet_providers"
   return(providers_info)
+}
+
+leaflet_providers_dependency <- function(version_num, providers_path) {
+  is_local <- !grepl("^https?://", providers_path)
+
+  src <- dirname(providers_path)
+  names(src) <- if (is_local) "file" else "href"
+
+  htmltools::htmlDependency(
+    name = "leaflet-providers",
+    version = version_num,
+    src = src,
+    script = basename(providers_path),
+    all_files = FALSE
+  )
 }
 
 
@@ -106,7 +123,11 @@ providers_default <- function() {
     "version_num" = providers_version_num,
     "providers" = providers_data,
     "providers_details" = providers_details_data,
-    "src" = js_lines
+    "src" = js_lines,
+    "dep" = leaflet_providers_dependency(
+      providers_version_num,
+      system.file(js_filename_for_inst, package = "leaflet.providers")
+    )
   )
 
   class(providers_info) <- "leaflet_providers"

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,3 @@
+.onLoad <- function(libname, pkgname) {
+  use_providers(providers_default())
+}

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ str(providers_default(), max.level = 2)
 
 <div style="height:150px; overflow-y: scroll;">
 
-    #> List of 4
+    #> List of 5
     #>  $ version_num      : chr "2.0.0"
     #>  $ providers        :List of 233
     #>   ..$ OpenStreetMap                         : chr "OpenStreetMap"
@@ -200,6 +200,18 @@ str(providers_default(), max.level = 2)
     #>   ..$ AzureMaps            :List of 3
     #>   ..$ SwissFederalGeoportal:List of 3
     #>  $ src              : chr "(function (root, factory) {\n\tif (typeof define === 'function' && define.amd) {\n\t\t// AMD. Register as an an"| __truncated__
+    #>  $ dep              :List of 10
+    #>   ..$ name      : chr "leaflet-providers"
+    #>   ..$ version   : chr "2.0.0"
+    #>   ..$ src       :List of 1
+    #>   ..$ meta      : NULL
+    #>   ..$ script    : chr "leaflet-providers_2.0.0.js"
+    #>   ..$ stylesheet: NULL
+    #>   ..$ head      : NULL
+    #>   ..$ attachment: NULL
+    #>   ..$ package   : NULL
+    #>   ..$ all_files : logi FALSE
+    #>   ..- attr(*, "class")= chr "html_dependency"
     #>  - attr(*, "class")= chr "leaflet_providers"
 
 </div>


### PR DESCRIPTION
Fixes #34

This is the first part in a two-step plan to ensure that the html dependency used in leaflet for leaflet.providers can be cached by knitr.

In this step, leaflet.providers will now include a `dep` item next to the previously returned `src` item. An [update to leaflet](https://github.com/rstudio/leaflet/pull/884) will use the `dep` if available, otherwise falling back to `src` and the previous temporary html dependency creation.

If no version is provided, we still look to unpkg to find the latest leaflet.providers version, but if the packaged version is up to date (or if the user requests the same version as the package) we use the local copy of `leaflet.providers`.

```r
get_providers()$dep
#> List of 10
#>  $ name      : chr "leaflet-providers"
#>  $ version   : chr "2.0.0"
#>  $ src       :List of 1
#>   ..$ file: chr "/Users/garrick/work/rstudio/leaflet.providers/inst"
#>  $ meta      : NULL
#>  $ script    : chr "leaflet-providers_2.0.0.js"
#>  $ stylesheet: NULL
#>  $ head      : NULL
#>  $ attachment: NULL
#>  $ package   : NULL
#>  $ all_files : logi FALSE
#>  - attr(*, "class")= chr "html_dependency"
```

If a non-local version is requested, we use a remote html dependency to pull that version from unpkg.

```r
get_providers("1.13.0")$dep
#> List of 10
#>  $ name      : chr "leaflet-providers"
#>  $ version   : chr "1.13.0"
#>  $ src       :List of 1
#>   ..$ href: chr "https://unpkg.com/leaflet-providers@1.13.0"
#>  $ meta      : NULL
#>  $ script    : chr "leaflet-providers.js"
#>  $ stylesheet: NULL
#>  $ head      : NULL
#>  $ attachment: NULL
#>  $ package   : NULL
#>  $ all_files : logi FALSE
#>  - attr(*, "class")= chr "html_dependency"
```